### PR TITLE
fix: use Node 24 and unset NODE_AUTH_TOKEN for npm OIDC publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: "24"
       - name: Install dependencies
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
@@ -30,4 +30,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: NODE_AUTH_TOKEN="" npx semantic-release
+        run: |
+          unset NODE_AUTH_TOKEN
+          npx semantic-release


### PR DESCRIPTION
## Summary

- Upgrade Node.js version from `lts/*` to `24` to meet npm OIDC trusted publishing requirements
- Replace `NODE_AUTH_TOKEN=""` with `unset NODE_AUTH_TOKEN` so the variable is fully removed before running `semantic-release`, allowing npm OIDC authentication to work correctly

## Root Cause

`actions/setup-node` injects `NODE_AUTH_TOKEN` into the environment when `registry-url` is configured. Setting it to an empty string (`""`) is not sufficient — npm OIDC requires the variable to be completely unset. Additionally, npm OIDC trusted publishing requires Node.js 24+ to function reliably.

Reference: https://github.com/actions/setup-node/issues/1440

## Test plan

- [ ] Verify the Release GitHub Actions workflow passes on merge to `main`
- [ ] Confirm npm package is published successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)